### PR TITLE
Associative comparison of schema.

### DIFF
--- a/tools/asset-inventory/asset_inventory/bigquery_schema.py
+++ b/tools/asset-inventory/asset_inventory/bigquery_schema.py
@@ -124,6 +124,13 @@ def get_field_by_name(fields, field_name):
     return None, None
 
 
+def is_additonal_properties(fields):
+    return fields and len(fields) == 2 and all(
+        (f.get('name', None) == 'name'
+         and f.get('description', None) == 'additionalProperties name')
+        or (f.get('name', None) == 'value') for f in fields)
+
+
 def _merge_fields(destination_field, source_field):
     """Combines two SchemaField like dicts.
 
@@ -143,44 +150,46 @@ def _merge_fields(destination_field, source_field):
     sd = source_field.get('description', None)
     dft = destination_field.get('field_type', None)
     sft = source_field.get('field_type', None)
-    # use the  field with more information.
+    # use the field with more information.
     if ((not dd and sd) or (sd and dd and len(dd) < len(sd))):
         field['description'] = sd
         field['field_type'] = sft
-    # use the less specific type.
+    # use the less specific type. and join fields
     elif ((dft != 'RECORD' and dft != 'STRING') and sft == 'STRING'):
         field['field_type'] = sft
-    df = destination_field.get('fields', [])
-    sf = source_field.get('fields', [])
 
-    # Do not create extra fields if the existing record is additionalProperties
-    # Extra columns will be transformed by EnforceSchemaDataTypes into {name:???, value:???}
-
-    # Check if the field has all 'additionalProperties' characteristics
-    fd_has_additionalProperties = len(df) == 2 and all(
-        ((
-            f.get('name', None) == 'name'
-            and f.get('description') == 'additionalProperties name'
-        ) or (
-            f.get('name', None) == 'value'
-        ))
-        for f in df
-        )
-
-    if fd_has_additionalProperties:
-        # merge types of all additional properties into 'value' field
-        merged_fields = copy.deepcopy(df)
-        i, value_field = get_field_by_name(merged_fields, 'value')
-        for f in sf:
+    # https://github.com/GoogleCloudPlatform/professional-services/issues/614
+    # Use the schema with the additonalProperties overrides. See
+    # api_schema._get_properties_map_field_list which creates the
+    # additionalProperties RECORD type and enforce_schema_data_types for where
+    # documents of type RECORD are converted to the REPEATED additonalProperties
+    # name value pairs.
+    def merge_additional_properties_fields(apf, fields):
+        i, value_field = get_field_by_name(apf, 'value')
+        for f in fields:
             if f.get('name', None) not in ('name', 'value'):
                 value_field = _merge_fields(value_field, f)
-        merged_fields[i] = value_field
-    else:
-        merged_fields = _merge_schema(df, sf)
-        # recursivly merge nested fields.
+        apf[i] = value_field
 
-    if merged_fields != df:
-        field['fields'] = merged_fields
+    sf = source_field.get('fields', [])
+    df = destination_field.get('fields', [])
+    if is_additonal_properties(sf) and not is_additonal_properties(df):
+        field['mode'] = 'REPEATED'
+        sf = copy.deepcopy(sf)
+        merge_additional_properties_fields(sf, df)
+        field['fields'] = sf
+    elif is_additonal_properties(df) and not is_additonal_properties(sf):
+        field['mode'] = 'REPEATED'
+        merge_additional_properties_fields(df, sf)
+        field['fields'] = df
+    elif is_additonal_properties(df) and is_additonal_properties(sf):
+        field['mode'] = 'REPEATED'
+        merge_additional_properties_fields(df, sf)
+        field['fields'] = df
+    else:
+        mf = _merge_schema(df, sf)
+        if mf:
+            field['fields'] = mf
     return field
 
 
@@ -473,6 +482,7 @@ def enforce_schema_data_types(resource, schema):
             if field.get('mode', 'NULLABLE') == 'REPEATED':
                 # satisfy array condition by converting dict into
                 # repeated name value records.
+                # this handles any 'additonalProperties' types.
                 if (field['field_type'] == 'RECORD' and
                     isinstance(resource_value, dict)):
                     resource_value = [{'name': key, 'value': val}

--- a/tools/asset-inventory/tests/test_bigquery_schema.py
+++ b/tools/asset-inventory/tests/test_bigquery_schema.py
@@ -22,6 +22,7 @@ from asset_inventory import bigquery_schema
 
 class TestBigQuerySchema(unittest.TestCase):
 
+
     def test_record(self):
         document = {'record_field': {'string_field': 'string_value'}}
         schema = bigquery_schema.translate_json_to_schema(
@@ -350,7 +351,7 @@ class TestBigQuerySchema(unittest.TestCase):
                          'field_type': 'STRING',
                          'description': 'description-2.',
                          'mode': 'NULLABLE'}]}]
-        
+
         document = {
             'property_1': 'value_1',
             'property_2': {
@@ -367,16 +368,13 @@ class TestBigQuerySchema(unittest.TestCase):
             bigquery_schema.merge_schemas(
                 [rest_schema, document_schema]
             ),
-            rest_schema +
-             [
-                {'name': 'property_3',
-                'field_type': 'STRING',
-                'mode': 'NULLABLE'
-                }
-             ]
-            )
+            rest_schema + [{'name': 'property_3',
+                            'field_type': 'STRING',
+                            'mode': 'NULLABLE'
+                           }])
 
     def test_addtional_properties_merge_schema_object(self):
+        self.maxDiff = None
         rest_schema = [
             {'name': 'property_1',
              'field_type': 'STRING',
@@ -393,9 +391,8 @@ class TestBigQuerySchema(unittest.TestCase):
                          'mode': 'NULLABLE'},
                         {'name': 'value',
                          'field_type': 'RECORD',
-                         #'description': 'description-2.',
                          'mode': 'NULLABLE'}]}]
-        
+
         document = {
             'property_1': 'value_1',
             'property_2': {
@@ -412,34 +409,29 @@ class TestBigQuerySchema(unittest.TestCase):
             bigquery_schema.merge_schemas(
                 [rest_schema, document_schema]
             ),
-            [
-            {'name': 'property_1',
-             'field_type': 'STRING',
-             'description': 'description-1',
-             'mode': 'NULLABLE'
-            },
-            {'name': 'property_2',
-             'field_type': 'RECORD',
-             'description': 'description-2',
-             'mode': 'REPEATED',
-             'fields': [{'name': 'name',
-                         'field_type': 'STRING',
-                         'description': 'additionalProperties name',
-                         'mode': 'NULLABLE'},
-                        {'name': 'value',
-                         'field_type': 'RECORD',
-                         'mode': 'NULLABLE',
-                         'fields': [{'name': 'key_1',
-                                     'field_type': 'NUMERIC',
-                                     'mode': 'NULLABLE'}]
-                         }]
-            },
-            {'name': 'property_3',
-             'field_type': 'STRING',
-             'mode': 'NULLABLE'
-            }
-            ]
-            )
+            [{'name': 'property_1',
+              'field_type': 'STRING',
+              'description': 'description-1',
+              'mode': 'NULLABLE'
+             },
+             {'name': 'property_2',
+              'field_type': 'RECORD',
+              'description': 'description-2',
+              'mode': 'REPEATED',
+              'fields': [{'name': 'name',
+                          'field_type': 'STRING',
+                          'description': 'additionalProperties name',
+                          'mode': 'NULLABLE'},
+                         {'name': 'value',
+                          'field_type': 'RECORD',
+                          'mode': 'NULLABLE',
+                          'fields': [{'name': 'key_1',
+                                      'field_type': 'NUMERIC',
+                                      'mode': 'NULLABLE'}]}]
+             },
+             {'name': 'property_3',
+              'field_type': 'STRING',
+              'mode': 'NULLABLE'}])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Francois, thank you very much for fixing this issue REALLY appreciate it.
I just wanted to corrections to the fix you proposed....

Combine function in beam should be associative so they should work when the arguments are passed in different orders. This fix attempts to do the same processing when the API schema and the document schema are in either argument position.
Just some formatting fixes, the tests you added are still the same and pass. Thank you for adding them!